### PR TITLE
kubernetes-controllers

### DIFF
--- a/kubernetes-controllers/deployment.yaml
+++ b/kubernetes-controllers/deployment.yaml
@@ -1,0 +1,55 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: hw2-deployment
+  labels: 
+    app: hw2
+  namespace: homework
+spec:
+  replicas: 3
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+       maxSurge: 0
+       maxUnavailable: 1
+  selector:
+    matchLabels: 
+      app: hw2
+  template:
+    metadata:
+      labels:
+        app: hw2
+    spec:
+      nodeSelector:
+        homework: "true"
+      containers:
+      - name: nginx
+        image: nginx
+        command: ["/bin/sh", "-c", "sed -i 's/listen  .*/listen 8000;/g' /etc/nginx/conf.d/default.conf && sed -i 's/usr\\/share\\/nginx\\/html/homework/g' /etc/nginx/conf.d/default.conf && exec nginx -g 'daemon off;'"]
+        ports:
+        - containerPort: 8000
+        volumeMounts:
+        - name: www
+          mountPath: "/homework"
+        readinessProbe:
+          exec:
+            command:
+              - cat
+              - /homework/index.html
+          initialDelaySeconds: 5
+          periodSeconds: 5
+        lifecycle:
+          preStop:
+            exec:
+              command: ["/usr/bin/rm", "-f", "/homework/index.html"]
+      initContainers:
+      - name: makeindex
+        image: busybox:1.28
+        command: ["sh", "-c", "echo \"<html>My second OTUS homework is done!</html>\" > /init/index.html"]
+        volumeMounts:
+        - name: www
+          mountPath: "/init"
+      volumes:
+      - name: www
+        emptyDir: {}
+

--- a/kubernetes-controllers/namespace.yaml
+++ b/kubernetes-controllers/namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: homework
+


### PR DESCRIPTION
# Выполнено ДЗ № 2

 - [+] Основное ДЗ
 - [+] Задание со *

## В процессе сделано:
 - Файл namespace.yaml для создания неймспейса homework;
 - Файл deployment.yaml для создания деплоймента из трех подов, описанных в ДЗ №1;

## Как запустить проект:
 - Создать метку "homework=true" на всех воркерах кластера Кубернетес командой kubectl label nodes worker1 worker2 worker3 homework=true , где worker1, worker2 и worker3 имена узлов кластера Кубернетес с ролью worker;
 - Создать неймспейс homework. Для этого выполнить команду kubectl apply -f namespace.yaml ;
 - Создать деплоймент hw2-deployment в неймспейсе homework. Для этого выполнить команду kubectl apply -f deployment.yaml ;

## Как проверить работоспособность:
 -  Проверка первого задания: все поды деплоймента запустились в неймспейсе homework:
 -  выполнить команду kubectl get po -n homework и убедиться, что все три пода находятся в состоянии Running;
 -  зайти в командную строку любого пода из состава деплоймента, выполнив команду kubectl exec -it имя_пода -n homework -- /bin/bash , выполнить команду curl http://localhost:8000/ и получив результат "My second OTUS homework is done!" убедиться в работоспособности подов;
 - Проверка второго задания: каждый под содержит Readiness пробу - проверка наличия файла /homework/index.html:
 - выбрать один из трех подов деплоймента и выполнить команду kubectl describe pod имя_пода -n homework и в выводе команды в разделе Conditions: убедиться в наличии Ready   True;
 - зайти в командную строку выбранного пода, выполнив команду kubectl exec -it имя_пода -n homework -- /bin/bash и удалить файл /homework/index.html командой rm /homework/index.html ;
 - выйти из командной строки пода, выполнив команду exit ;
 - выполнить команду kubectl describe pod имя_пода -n homework , где имя пода - имя пода, в котором удален файл index.html и в выводе команды в разделе Conditions: убедиться в наличии Ready   False;
 - Проверка третьего задания: Деплоймент будет иметь стратегию обновления RollingUpdate, настроенную так,
что в процессе обновления может быть недоступен максимум 1 под:
- Произвести рестарт всех подов деплоймента одновременно выполнив команду kubectl rollout restart deployment hw2-deployment -n homework ;
- Периодически выполняя команду kubectl get po -n homework убедиться, что рестарт подов происходит строго по одному таким образом, что два пода всегда доступны, что отвечает настройке стратегии обновления;
- Проверка задания со звездочкой: Добавить к манифесту deployment-а спецификацию,
обеспечивающую запуск подов деплоймента, только на нодах
кластера, имеющих метку homework=true:
- проверить наличие метки на воркерах выполнив команду kubectl get no --show-labels , убедиться в наличии метки "homework=true" на каждом воркере;
- убрать отметку "homework=true" с любого воркера командой kubectl label nodes workerX homework- , где workerX - имя воркера, с которого убирается метка;
- удалить неймспейс командой kubectl delete ns homework и заново развернуть деплоймент командами kubectl apply -f namespace.yaml и kubectl apply -f deployment.yaml ;
- выполнить команду kubectl get po -n homework -o wide и убедиться в том, что все поды деплоймента запущены только на тех воркерах, которые имеют метку "homework=true".
- Домашнее задание № 2 выполнено полностью. 


 
 

## PR checklist:
 - [ ] Выставлен label с темой домашнего задания
